### PR TITLE
:sparkles:-FEATURE: Added mol_to_svg() support for django

### DIFF
--- a/django_rdkit/models/functions.py
+++ b/django_rdkit/models/functions.py
@@ -38,6 +38,7 @@ for function, fieldkls in [('mol', MolField),
                            ('mol_inchi', models.TextField),
                            ('mol_inchikey', models.TextField),
                            ('mol_formula', models.TextField),
+                           ('mol_to_svg', models.TextField),
                        ]:
     _F = type(str(function.upper()), (_Func,),
              { 'function': function, 'default_output_field': fieldkls(),})

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -201,6 +201,7 @@ class MolFieldTest(TestCase):
                 MOL_INCHI,
                 MOL_INCHIKEY,
                 MOL_FORMULA,
+                MOL_TO_SVG,
         ):
             _ = list(MoleculeModel.objects.annotate(result=func('molecule')))
 


### PR DESCRIPTION
Added `mol_to_svg()` so that we can generate svgs on the fly through django.