### PR TITLE
replace deprecated ugettext_lazy for gettext_lazy since the former is deprecated/totally removed

### DIFF
--- a/django_rdkit/models/fields.py
+++ b/django_rdkit/models/fields.py
@@ -1,5 +1,5 @@
 from django import VERSION as DJANGO_VERSION
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.db.models import Lookup, Transform, Func
 from django.db.models.fields import *
 from django.core.exceptions import ValidationError


### PR DESCRIPTION
see https://docs.djangoproject.com/en/dev/internals/deprecation/#deprecation-removed-in-4-0 for proof of removal