### PR TITLE
Fix mistake in tutorial.rst

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -386,7 +386,8 @@ The following demonstrate a basic similarity search::
   
   In [4]: value = MORGANBV_FP(Value(smiles))
   
-  In [5]: Compound.objects.filter(mfp2__tanimoto=value).count()Out[6]: 67
+  In [5]: Compound.objects.filter(mfp2__tanimoto=value).count()
+  Out[6]: 67
 
 Following the original tutorial from the RDKit documentation, the next step consists in implementing a query to return the sorted list of neighbors along with the accompanying SMILES::
 


### PR DESCRIPTION
In one of the code snippets, the output was on the same line as the input. This change shifts the output onto a new line.