### PR TITLE
Allow transferring MolField data as text (smiles)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.4.0]
+
+### Added
+- `Mol` data can be now transferred to/from the database as either binary or text, depending on the
+  value assigned to the `DJANGO_RDKIT_MOL_SERIALIZATION` settings attribute (allowed values are
+  `BINARY` and `TEXT`, defaults to `BINARY`)
+
 ## [0.3.2]
 
 ### Fixed

--- a/django_rdkit/models/fields.py
+++ b/django_rdkit/models/fields.py
@@ -1,4 +1,3 @@
-from django import VERSION as DJANGO_VERSION
 from django.utils.translation import gettext_lazy as _
 from django.db.models import Lookup, Transform, Func, Value
 from django.db.models.fields import *
@@ -24,13 +23,7 @@ class MolField(Field):
 
     def get_placeholder(self, value, compiler, connection):
         if hasattr(value, 'as_sql'):
-            if DJANGO_VERSION > (2,):
-                return '%s'
-            else:
-                # No value used for expressions, substitute in
-                # the column name instead.
-                sql, _ = compiler.compile(value)
-                return sql
+            return '%s'
         else:
             return 'mol_from_pkl(%s)'
 
@@ -139,13 +132,7 @@ class BfpField(Field):
 
     def get_placeholder(self, value, compiler, connection):
         if hasattr(value, 'as_sql'):
-            if DJANGO_VERSION > (2,):
-                return '%s'
-            else:
-                # No value used for expressions, substitute in
-                # the column name instead.
-                sql, _ = compiler.compile(value)
-                return sql
+            return '%s'
         else:
             return 'bfp_from_binary_text(%s)'
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,7 @@ Contents:
    lookups
    functions
    guc
+   settings
 
 Indices and tables
 ==================

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -1,0 +1,11 @@
+Django settings
+===============
+
+The following django settings are supported:
+
+``DJANGO_RDKIT_MOL_SERIALIZATION``
+..................................
+
+Default: ``'BINARY'``
+
+Controls whether the value associated to a ``MolField`` is transferred to/from the database as a binary serialized (pickled) RDKit molecule, or as a SMILES text string. Supported values are: ``BINARY``, ``TEXT``.

--- a/runtests.py
+++ b/runtests.py
@@ -22,6 +22,8 @@ DEFAULT_SETTINGS = dict(
         }
     },
     DEFAULT_AUTO_FIELD='django.db.models.BigAutoField',
+
+    DJANGO_RDKIT_MOL_SERIALIZATION=os.environ.get('DJANGO_RDKIT_MOL_SERIALIZATION', 'BINARY'),
 )
 
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def get_packages(package):
 
 setup(
     name='django-rdkit',
-    version='0.3.2',
+    version='0.4.0',
     description='',
     packages = get_packages('django_rdkit'),
     zip_safe=False,


### PR DESCRIPTION
This PR allows transferring the `MolField` data as either binary or text (smiles) depending on the value assigned to the `DJANGO_RDKIT_MOL_SERIALIZATION` settings attribute.

This should help allowing different versions of RDKit to run on the client and database server sides, which might otherwise use incompatible binary serialization formats.