### PR TITLE
add new param for enhanced stereo sss

### DIFF
--- a/django_rdkit/config.py
+++ b/django_rdkit/config.py
@@ -4,6 +4,7 @@ _PARAMETERS = (
     'tanimoto_threshold',
     'dice_threshold',
     'do_chiral_sss',
+    'do_enhanced_stereo_sss',
     'sss_fp_size',
     'morgan_fp_size',
     'featmorgan_fp_size',


### PR DESCRIPTION
Looks like there is a new-ish parameter for [enhanced stereo during substructure searching](https://www.rdkit.org/docs/Cartridge.html#parameters): `do_enhanced_stereo_sss`. Currently, if I try setting that, I get an exception:


```
self = <django_rdkit.config.Config object at 0x7fffc8214460>
name = 'do_enhanced_stereo_sss', value = True

    def __setattr__(self, name, value):
        if not name in _PARAMETERS:
>           raise AttributeError
E           AttributeError

/usr/local/lib/python3.10/site-packages/django_rdkit/config.py:28: AttributeError
```

This adds support for setting that value via `django_rdkit`. Monkey-patching locally with this works when doing searches in Postgres with the RDKit cartridge.