### PR TITLE
fix: change `Expression.resolve_expression` signature to match Django

### DIFF
--- a/django_rdkit/models/functions.py
+++ b/django_rdkit/models/functions.py
@@ -151,11 +151,11 @@ class DistanceExpression(Expression):
         self.lhs, self.rhs = exprs
 
     def resolve_expression(self, query=None,
-                           allow_joins=True, reuse=None, summarize=False):
+                           allow_joins=True, reuse=None, summarize=False, for_save=False):
         c = self.copy()
         c.is_summary = summarize
-        c.lhs = self.lhs.resolve_expression(query, allow_joins, reuse, summarize)
-        c.rhs = self.rhs.resolve_expression(query, allow_joins, reuse, summarize)
+        c.lhs = self.lhs.resolve_expression(query, allow_joins, reuse, summarize, for_save)
+        c.rhs = self.rhs.resolve_expression(query, allow_joins, reuse, summarize, for_save)
         return c
 
     def as_sql(self, compiler, connection):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -373,6 +373,26 @@ class BfpFieldTest3(TestCase):
                              list(obfp.GetOnBits()))
 
 
+class DistanceExpressionTest(TestCase):
+    """Test TANIMOTO_DIST and DICE_DIST distance expressions."""
+
+    def setUp(self):
+        for smiles in SMILES_SAMPLE:
+            record = BfpModel.objects.create()
+            record.bfp = MORGANBV_FP(Value(smiles))
+            record.save()
+
+    def test_tanimoto_dist_order_by(self):
+        query_bfp = MORGANBV_FP(Value('CCN1c2ccccc2Sc2ccccc21'))
+        objs = list(BfpModel.objects.order_by(TANIMOTO_DIST('bfp', query_bfp))[:5])
+        self.assertEqual(len(objs), 5)
+
+    def test_dice_dist_order_by(self):
+        query_bfp = MORGANBV_FP(Value('CCN1c2ccccc2Sc2ccccc21'))
+        objs = list(BfpModel.objects.order_by(DICE_DIST('bfp', query_bfp))[:5])
+        self.assertEqual(len(objs), 5)
+
+
 class SfpFieldTest1(TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Django's `Expression.resolve_expression` method has the [following signature](https://docs.djangoproject.com/en/5.2/ref/models/expressions/#django.db.models.Expression.resolve_expression):

```python
def resolve_expression(query=None, allow_joins=True, reuse=None, summarize=False, for_save=False):
    ...
```

whereas in this project, `DistanceExpression.resolve_expression` is:

```python
def resolve_expression(self, query=None, allow_joins=True, reuse=None, summarize=False):
    ...
```

So we're missing `for_save`, which if Django passes to the expression classes that inherit from `DistanceExpression` results in a `TypeError: DistanceExpression.resolve_expression() takes from 1 to 5 positional arguments but 6 were given`.

However, I've never hit this error until Django 5.2. I think `for_save` was not propagated before that point. I added test cases covering this functionality and performed some tests on my fork:
- Failures specifically with Django 5.2 before fix: https://github.com/radusuciu/django-rdkit/actions/runs/19875985233/
- All passing after fix: https://github.com/radusuciu/django-rdkit/actions/runs/19876042784/

I'm happy to contribute the test workflow as well if you're interested.